### PR TITLE
fix: update USGS API parameter code for reservoir data

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,13 @@
+import { Html, Head, Main, NextScript } from 'next/document'
+
+export default function Document() {
+  return (
+    <Html lang="es">
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  )
+}

--- a/pages/embalse.js
+++ b/pages/embalse.js
@@ -12,10 +12,21 @@ Embalse.getInitialProps = async function (req) {
   const { id } = req.query
   const myEmbalses = new EmbalsesApi()
 
-  const res = await fetch(`https://waterservices.usgs.gov/nwis/iv/?format=json&sites=${id}&period=P30D&parameterCd=62616&siteStatus=all`, {mode: 'cors'})
-  const data = await res.json()
-
-  return myEmbalses.processUsgsEmbalses(data)[0]
+  try {
+    const res = await fetch(`https://waterservices.usgs.gov/nwis/iv/?format=json&sites=${id}&period=P30D&parameterCd=72376&siteStatus=all`, {mode: 'cors'})
+    
+    if (!res.ok) {
+      console.error('USGS API error:', res.status, res.statusText)
+      return { commonName: 'Unknown', siteName: 'Data unavailable' }
+    }
+    
+    const data = await res.json()
+    const embalses = myEmbalses.processUsgsEmbalses(data)
+    return embalses[0] || { commonName: 'Unknown', siteName: 'Data unavailable' }
+  } catch (error) {
+    console.error('Failed to fetch USGS data:', error.message)
+    return { commonName: 'Unknown', siteName: 'Data unavailable' }
+  }
 }
 
 export default Embalse

--- a/pages/index.js
+++ b/pages/index.js
@@ -26,11 +26,19 @@ Index.getInitialProps = async function () {
   const myEmbalses = new EmbalsesApi()
   const sites = myEmbalses.ids.join(',')
 
-  const res = await fetch(`https://waterservices.usgs.gov/nwis/iv/?format=json&sites=${sites}&parameterCd=62616&siteStatus=all`, {mode: 'cors'})
-  const data = await res.json()
-
-  return {
-    embalses: myEmbalses.processUsgsEmbalses(data)
+  try {
+    const res = await fetch(`https://waterservices.usgs.gov/nwis/iv/?format=json&sites=${sites}&parameterCd=72376&siteStatus=all`, {mode: 'cors'})
+    
+    if (!res.ok) {
+      console.error('USGS API error:', res.status, res.statusText)
+      return { embalses: [] }
+    }
+    
+    const data = await res.json()
+    return { embalses: myEmbalses.processUsgsEmbalses(data) }
+  } catch (error) {
+    console.error('Failed to fetch USGS data:', error.message)
+    return { embalses: [] }
   }
 }
 


### PR DESCRIPTION
## Problem
The USGS API was returning empty results because the project was using parameter code  (Gage height, feet), which is not reported by the Puerto Rico reservoir stations.

## Solution
Updated to parameter code  (Lake/reservoir elevation above local mean sea level, meters) which is the correct parameter these stations report.

### Changes
- Updated  from  to  in both  and 
- Added error handling for USGS API calls
- Added  for Next.js 14 compatibility

### Before


### After
