### PR TITLE
feat: separate map and table into their own pages

### DIFF
--- a/__tests__/Header.test.js
+++ b/__tests__/Header.test.js
@@ -12,11 +12,10 @@ describe('Header', () => {
   it('renders navigation links', () => {
     render(<Header />)
     
-    const homeLink = screen.getByText('Home')
-    const aboutLink = screen.getByText('About')
-    
-    expect(homeLink).toBeInTheDocument()
-    expect(aboutLink).toBeInTheDocument()
+    expect(screen.getByText('Home')).toBeInTheDocument()
+    expect(screen.getByText('Map')).toBeInTheDocument()
+    expect(screen.getByText('Table')).toBeInTheDocument()
+    expect(screen.getByText('About')).toBeInTheDocument()
   })
 
   it('has correct href for Home link', () => {
@@ -24,6 +23,20 @@ describe('Header', () => {
     
     const homeLink = screen.getByText('Home')
     expect(homeLink).toHaveAttribute('href', '/')
+  })
+
+  it('has correct href for Map link', () => {
+    render(<Header />)
+    
+    const mapLink = screen.getByText('Map')
+    expect(mapLink).toHaveAttribute('href', '/map')
+  })
+
+  it('has correct href for Table link', () => {
+    render(<Header />)
+    
+    const tableLink = screen.getByText('Table')
+    expect(tableLink).toHaveAttribute('href', '/table')
   })
 
   it('has correct href for About link', () => {

--- a/components/Header.js
+++ b/components/Header.js
@@ -6,6 +6,12 @@ const Header = () => (
       <Link href='/' className='nav-link'>Home</Link>
     </li>
     <li className='nav-item'>
+      <Link href='/map' className='nav-link'>Map</Link>
+    </li>
+    <li className='nav-item'>
+      <Link href='/table' className='nav-link'>Table</Link>
+    </li>
+    <li className='nav-item'>
       <Link href='/about' className='nav-link'>About</Link>
     </li>
   </ul>

--- a/pages/map.js
+++ b/pages/map.js
@@ -1,19 +1,17 @@
 import Layout from '../components/MyLayout.js'
 import EmbalsesApi from '../components/EmbalsesApi.js'
-import Niveles from '../components/Niveles.js'
+import dynamic from 'next/dynamic'
 
-const Index = (props) => (
+const EmbalsesMap = dynamic(() => import('../components/EmbalsesMap.js'), {ssr: false})
+
+const MapPage = (props) => (
   <Layout>
-    <h1>Puerto Rico Reservoir Levels</h1>
-    <div className='row'>
-      <div className='col'>
-        <Niveles embalses={props.embalses} />
-      </div>
-    </div>
+    <h1>Reservoir Map</h1>
+    <EmbalsesMap embalses={props.embalses} />
   </Layout>
 )
 
-Index.getInitialProps = async function () {
+MapPage.getInitialProps = async function () {
   const myEmbalses = new EmbalsesApi()
   const sites = myEmbalses.ids.join(',')
 
@@ -33,4 +31,4 @@ Index.getInitialProps = async function () {
   }
 }
 
-export default Index
+export default MapPage

--- a/pages/table.js
+++ b/pages/table.js
@@ -1,19 +1,15 @@
 import Layout from '../components/MyLayout.js'
 import EmbalsesApi from '../components/EmbalsesApi.js'
-import Niveles from '../components/Niveles.js'
+import EmbalsesTable from '../components/EmbalsesTable.js'
 
-const Index = (props) => (
+const TablePage = (props) => (
   <Layout>
-    <h1>Puerto Rico Reservoir Levels</h1>
-    <div className='row'>
-      <div className='col'>
-        <Niveles embalses={props.embalses} />
-      </div>
-    </div>
+    <h1>Reservoir Data</h1>
+    <EmbalsesTable embalses={props.embalses} />
   </Layout>
 )
 
-Index.getInitialProps = async function () {
+TablePage.getInitialProps = async function () {
   const myEmbalses = new EmbalsesApi()
   const sites = myEmbalses.ids.join(',')
 
@@ -33,4 +29,4 @@ Index.getInitialProps = async function () {
   }
 }
 
-export default Index
+export default TablePage


### PR DESCRIPTION
## Changes
- Create  page with interactive map
- Create  page with data table
- Simplify home page to show only chart
- Update navigation with new page links

## Pages
| Route | Content |
|-------|---------|
|  | Chart (Niveles) |
|  | Interactive map with markers |
|  | Data table with all reservoirs |
|  | About page |