### PR TITLE
feat: add internationalization with Spanish default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 .DS_Store
 /.env.production
 .vercel
+.dir-locals.el

--- a/__tests__/EmbalsesMap.test.js
+++ b/__tests__/EmbalsesMap.test.js
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import EmbalsesMap from '../components/EmbalsesMap'
+import { LanguageProvider } from '../context/LanguageContext'
 
 // Mock react-leaflet
 jest.mock('react-leaflet', () => ({
@@ -29,6 +30,14 @@ jest.mock('next/link', () => {
   }
 })
 
+const renderWithLanguage = (ui) => {
+  return render(
+    <LanguageProvider>
+      {ui}
+    </LanguageProvider>
+  )
+}
+
 const mockEmbalses = [
   {
     id: 50059000,
@@ -48,13 +57,13 @@ const mockEmbalses = [
 
 describe('EmbalsesMap', () => {
   it('renders the map container', () => {
-    render(<EmbalsesMap embalses={mockEmbalses} />)
+    renderWithLanguage(<EmbalsesMap embalses={mockEmbalses} />)
     
     expect(screen.getByTestId('map-container')).toBeInTheDocument()
   })
 
   it('renders with correct center position', () => {
-    render(<EmbalsesMap embalses={mockEmbalses} />)
+    renderWithLanguage(<EmbalsesMap embalses={mockEmbalses} />)
     
     const map = screen.getByTestId('map-container')
     const center = JSON.parse(map.dataset.center)
@@ -63,27 +72,27 @@ describe('EmbalsesMap', () => {
   })
 
   it('renders with zoom level 9', () => {
-    render(<EmbalsesMap embalses={mockEmbalses} />)
+    renderWithLanguage(<EmbalsesMap embalses={mockEmbalses} />)
     
     const map = screen.getByTestId('map-container')
     expect(map.dataset.zoom).toBe('9')
   })
 
   it('renders tile layer', () => {
-    render(<EmbalsesMap embalses={mockEmbalses} />)
+    renderWithLanguage(<EmbalsesMap embalses={mockEmbalses} />)
     
     expect(screen.getByTestId('tile-layer')).toBeInTheDocument()
   })
 
   it('renders markers for each embalse', () => {
-    render(<EmbalsesMap embalses={mockEmbalses} />)
+    renderWithLanguage(<EmbalsesMap embalses={mockEmbalses} />)
     
     const markers = screen.getAllByTestId('marker')
     expect(markers).toHaveLength(2)
   })
 
   it('renders marker positions correctly', () => {
-    render(<EmbalsesMap embalses={mockEmbalses} />)
+    renderWithLanguage(<EmbalsesMap embalses={mockEmbalses} />)
     
     const markers = screen.getAllByTestId('marker')
     const firstPosition = JSON.parse(markers[0].dataset.position)
@@ -94,28 +103,28 @@ describe('EmbalsesMap', () => {
   })
 
   it('renders popup with embalse name', () => {
-    render(<EmbalsesMap embalses={mockEmbalses} />)
+    renderWithLanguage(<EmbalsesMap embalses={mockEmbalses} />)
     
     expect(screen.getByText('Carraizo')).toBeInTheDocument()
     expect(screen.getByText('La Plata')).toBeInTheDocument()
   })
 
-  it('renders popup with current level', () => {
-    render(<EmbalsesMap embalses={mockEmbalses} />)
+  it('renders popup with translated alert and level', () => {
+    renderWithLanguage(<EmbalsesMap embalses={mockEmbalses} />)
     
-    expect(screen.getByText(/38.5 meters/)).toBeInTheDocument()
-    expect(screen.getByText(/48.2 meters/)).toBeInTheDocument()
+    expect(screen.getByText(/Observación/)).toBeInTheDocument()
+    expect(screen.getByText(/38.5 m/)).toBeInTheDocument()
   })
 
   it('links popup to embalse detail page', () => {
-    render(<EmbalsesMap embalses={mockEmbalses} />)
+    renderWithLanguage(<EmbalsesMap embalses={mockEmbalses} />)
     
     const carraizoLink = screen.getByText('Carraizo')
     expect(carraizoLink).toHaveAttribute('href', '/embalse?id=50059000')
   })
 
   it('renders empty when no embalses', () => {
-    render(<EmbalsesMap embalses={[]} />)
+    renderWithLanguage(<EmbalsesMap embalses={[]} />)
     
     const markers = screen.queryAllByTestId('marker')
     expect(markers).toHaveLength(0)

--- a/__tests__/EmbalsesTable.test.js
+++ b/__tests__/EmbalsesTable.test.js
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import EmbalsesTable from '../components/EmbalsesTable'
+import { LanguageProvider } from '../context/LanguageContext'
 
 // Mock Next.js Link
 jest.mock('next/link', () => {
@@ -7,6 +8,14 @@ jest.mock('next/link', () => {
     return <a href={href} {...props}>{children}</a>
   }
 })
+
+const renderWithLanguage = (ui) => {
+  return render(
+    <LanguageProvider>
+      {ui}
+    </LanguageProvider>
+  )
+}
 
 const mockEmbalses = [
   {
@@ -28,45 +37,45 @@ const mockEmbalses = [
 ]
 
 describe('EmbalsesTable', () => {
-  it('renders table headers', () => {
-    render(<EmbalsesTable embalses={[]} />)
+  it('renders table headers in Spanish', () => {
+    renderWithLanguage(<EmbalsesTable embalses={[]} />)
     
     expect(screen.getByText('Embalse')).toBeInTheDocument()
-    expect(screen.getByText('Last Updated')).toBeInTheDocument()
-    expect(screen.getByText('Current Alert')).toBeInTheDocument()
-    expect(screen.getByText('Current Level (meters)')).toBeInTheDocument()
+    expect(screen.getByText('Última Actualización')).toBeInTheDocument()
+    expect(screen.getByText('Alerta Actual')).toBeInTheDocument()
+    expect(screen.getByText('Nivel Actual (metros)')).toBeInTheDocument()
   })
 
   it('renders embalse rows', () => {
-    render(<EmbalsesTable embalses={mockEmbalses} />)
+    renderWithLanguage(<EmbalsesTable embalses={mockEmbalses} />)
     
     expect(screen.getByText('Carraizo')).toBeInTheDocument()
     expect(screen.getByText('La Plata')).toBeInTheDocument()
   })
 
-  it('renders current alert levels', () => {
-    render(<EmbalsesTable embalses={mockEmbalses} />)
+  it('renders translated alert levels', () => {
+    renderWithLanguage(<EmbalsesTable embalses={mockEmbalses} />)
     
-    expect(screen.getByText('Observacion')).toBeInTheDocument()
+    expect(screen.getByText('Observación')).toBeInTheDocument()
     expect(screen.getByText('Seguridad')).toBeInTheDocument()
   })
 
   it('renders current values', () => {
-    render(<EmbalsesTable embalses={mockEmbalses} />)
+    renderWithLanguage(<EmbalsesTable embalses={mockEmbalses} />)
     
     expect(screen.getByText('38.5')).toBeInTheDocument()
     expect(screen.getByText('48.2')).toBeInTheDocument()
   })
 
   it('links to embalse detail page', () => {
-    render(<EmbalsesTable embalses={mockEmbalses} />)
+    renderWithLanguage(<EmbalsesTable embalses={mockEmbalses} />)
     
     const carraizoLink = screen.getByText('Carraizo')
     expect(carraizoLink).toHaveAttribute('href', '/embalse?id=50059000')
   })
 
   it('renders empty table body when no embalses', () => {
-    render(<EmbalsesTable embalses={[]} />)
+    renderWithLanguage(<EmbalsesTable embalses={[]} />)
     
     const rows = screen.queryAllByRole('row')
     // Only header row

--- a/__tests__/Header.test.js
+++ b/__tests__/Header.test.js
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import Header from '../components/Header'
+import { LanguageProvider } from '../context/LanguageContext'
 
 // Mock Next.js Link
 jest.mock('next/link', () => {
@@ -8,48 +9,55 @@ jest.mock('next/link', () => {
   }
 })
 
+const renderWithLanguage = (ui) => {
+  return render(
+    <LanguageProvider>
+      {ui}
+    </LanguageProvider>
+  )
+}
+
 describe('Header', () => {
-  it('renders navigation links', () => {
-    render(<Header />)
+  it('renders navigation links in Spanish (default)', () => {
+    renderWithLanguage(<Header />)
     
-    expect(screen.getByText('Home')).toBeInTheDocument()
-    expect(screen.getByText('Map')).toBeInTheDocument()
-    expect(screen.getByText('Table')).toBeInTheDocument()
-    expect(screen.getByText('About')).toBeInTheDocument()
+    expect(screen.getByText('Inicio')).toBeInTheDocument()
+    expect(screen.getByText('Mapa')).toBeInTheDocument()
+    expect(screen.getByText('Tabla')).toBeInTheDocument()
+    expect(screen.getByText('Acerca de')).toBeInTheDocument()
   })
 
   it('has correct href for Home link', () => {
-    render(<Header />)
+    renderWithLanguage(<Header />)
     
-    const homeLink = screen.getByText('Home')
+    const homeLink = screen.getByText('Inicio')
     expect(homeLink).toHaveAttribute('href', '/')
   })
 
   it('has correct href for Map link', () => {
-    render(<Header />)
+    renderWithLanguage(<Header />)
     
-    const mapLink = screen.getByText('Map')
+    const mapLink = screen.getByText('Mapa')
     expect(mapLink).toHaveAttribute('href', '/map')
   })
 
   it('has correct href for Table link', () => {
-    render(<Header />)
+    renderWithLanguage(<Header />)
     
-    const tableLink = screen.getByText('Table')
+    const tableLink = screen.getByText('Tabla')
     expect(tableLink).toHaveAttribute('href', '/table')
   })
 
   it('has correct href for About link', () => {
-    render(<Header />)
+    renderWithLanguage(<Header />)
     
-    const aboutLink = screen.getByText('About')
+    const aboutLink = screen.getByText('Acerca de')
     expect(aboutLink).toHaveAttribute('href', '/about')
   })
 
-  it('renders as a nav list', () => {
-    render(<Header />)
+  it('renders language toggle button', () => {
+    renderWithLanguage(<Header />)
     
-    const nav = screen.getByRole('list')
-    expect(nav).toHaveClass('nav')
+    expect(screen.getByText('EN')).toBeInTheDocument()
   })
 })

--- a/__tests__/MyLayout.test.js
+++ b/__tests__/MyLayout.test.js
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import MyLayout from '../components/MyLayout'
+import { LanguageProvider } from '../context/LanguageContext'
 
 // Mock Next.js Link
 jest.mock('next/link', () => {
@@ -8,22 +9,30 @@ jest.mock('next/link', () => {
   }
 })
 
+const renderWithLanguage = (ui) => {
+  return render(
+    <LanguageProvider>
+      {ui}
+    </LanguageProvider>
+  )
+}
+
 describe('MyLayout', () => {
   it('renders header navigation', () => {
-    render(<MyLayout><div>Content</div></MyLayout>)
+    renderWithLanguage(<MyLayout><div>Content</div></MyLayout>)
     
-    expect(screen.getByText('Home')).toBeInTheDocument()
-    expect(screen.getByText('About')).toBeInTheDocument()
+    expect(screen.getByText('Inicio')).toBeInTheDocument()
+    expect(screen.getByText('Acerca de')).toBeInTheDocument()
   })
 
   it('renders children content', () => {
-    render(<MyLayout><div>Test Content</div></MyLayout>)
+    renderWithLanguage(<MyLayout><div>Test Content</div></MyLayout>)
     
     expect(screen.getByText('Test Content')).toBeInTheDocument()
   })
 
   it('renders nested components', () => {
-    render(
+    renderWithLanguage(
       <MyLayout>
         <h1>Title</h1>
         <p>Paragraph</p>
@@ -35,9 +44,9 @@ describe('MyLayout', () => {
   })
 
   it('has container divs', () => {
-    const { container } = render(<MyLayout><div>Content</div></MyLayout>)
+    const { container } = renderWithLanguage(<MyLayout><div>Content</div></MyLayout>)
     
     const containers = container.querySelectorAll('.container')
-    expect(containers.length).toBe(2)
+    expect(containers.length).toBeGreaterThanOrEqual(2)
   })
 })

--- a/__tests__/Niveles.test.js
+++ b/__tests__/Niveles.test.js
@@ -57,16 +57,16 @@ describe('Niveles', () => {
     expect(data.labels).toEqual(['Carraizo', 'La Plata'])
   })
 
-  it('calculates percentage of desborde level', () => {
+  it('calculates percentage between control and desborde levels', () => {
     render(<Niveles embalses={mockEmbalses} />)
     
     const chart = screen.getByTestId('bar-chart')
     const data = JSON.parse(chart.dataset.chartData)
     
-    // Carraizo: 38.5 / 40.8 * 100 = 94%
-    // La Plata: 48.2 / 51.3 * 100 = 94%
-    expect(data.datasets[0].data[0]).toBe(94)
-    expect(data.datasets[0].data[1]).toBe(94)
+    // Carraizo: (38.5 - 31.5) / (40.8 - 31.5) * 100 = 7 / 9.3 * 100 = 75%
+    // La Plata: (48.2 - 32) / (51.3 - 32) * 100 = 16.2 / 19.3 * 100 = 84%
+    expect(data.datasets[0].data[0]).toBe(75)
+    expect(data.datasets[0].data[1]).toBe(84)
   })
 
   it('colors bars based on alert level', () => {

--- a/__tests__/Niveles.test.js
+++ b/__tests__/Niveles.test.js
@@ -57,24 +57,16 @@ describe('Niveles', () => {
     expect(data.labels).toEqual(['Carraizo', 'La Plata'])
   })
 
-  it('creates a single dataset with all values', () => {
+  it('calculates percentage of desborde level', () => {
     render(<Niveles embalses={mockEmbalses} />)
     
     const chart = screen.getByTestId('bar-chart')
     const data = JSON.parse(chart.dataset.chartData)
     
-    expect(data.datasets).toHaveLength(1)
-    expect(data.datasets[0].label).toBe('Nivel Actual')
-  })
-
-  it('includes current values in dataset data', () => {
-    render(<Niveles embalses={mockEmbalses} />)
-    
-    const chart = screen.getByTestId('bar-chart')
-    const data = JSON.parse(chart.dataset.chartData)
-    
-    expect(data.datasets[0].data).toContain(38.5)
-    expect(data.datasets[0].data).toContain(48.2)
+    // Carraizo: 38.5 / 40.8 * 100 = 94%
+    // La Plata: 48.2 / 51.3 * 100 = 94%
+    expect(data.datasets[0].data[0]).toBe(94)
+    expect(data.datasets[0].data[1]).toBe(94)
   })
 
   it('colors bars based on alert level', () => {
@@ -95,6 +87,15 @@ describe('Niveles', () => {
     const options = JSON.parse(chart.dataset.chartOptions)
     
     expect(options.plugins.legend.display).toBe(false)
+  })
+
+  it('sets y-axis max to 100', () => {
+    render(<Niveles embalses={mockEmbalses} />)
+    
+    const chart = screen.getByTestId('bar-chart')
+    const options = JSON.parse(chart.dataset.chartOptions)
+    
+    expect(options.scales.y.max).toBe(100)
   })
 
   it('starts y-axis at zero', () => {

--- a/__tests__/Niveles.test.js
+++ b/__tests__/Niveles.test.js
@@ -57,25 +57,14 @@ describe('Niveles', () => {
     expect(data.labels).toEqual(['Carraizo', 'La Plata'])
   })
 
-  it('creates datasets for each embalse', () => {
+  it('creates a single dataset with all values', () => {
     render(<Niveles embalses={mockEmbalses} />)
     
     const chart = screen.getByTestId('bar-chart')
     const data = JSON.parse(chart.dataset.chartData)
     
-    expect(data.datasets).toHaveLength(2)
-    expect(data.datasets[0].label).toBe('observacion')
-    expect(data.datasets[1].label).toBe('seguridad')
-  })
-
-  it('sets correct yAxisID for each dataset', () => {
-    render(<Niveles embalses={mockEmbalses} />)
-    
-    const chart = screen.getByTestId('bar-chart')
-    const data = JSON.parse(chart.dataset.chartData)
-    
-    expect(data.datasets[0].yAxisID).toBe(50059000)
-    expect(data.datasets[1].yAxisID).toBe(50045000)
+    expect(data.datasets).toHaveLength(1)
+    expect(data.datasets[0].label).toBe('Nivel Actual')
   })
 
   it('includes current values in dataset data', () => {
@@ -84,9 +73,19 @@ describe('Niveles', () => {
     const chart = screen.getByTestId('bar-chart')
     const data = JSON.parse(chart.dataset.chartData)
     
-    // Data is sparse with nulls - value is at index matching embalse position
-    expect(data.datasets[0].data).toContain('38.5')
-    expect(data.datasets[1].data).toContain('48.2')
+    expect(data.datasets[0].data).toContain(38.5)
+    expect(data.datasets[0].data).toContain(48.2)
+  })
+
+  it('colors bars based on alert level', () => {
+    render(<Niveles embalses={mockEmbalses} />)
+    
+    const chart = screen.getByTestId('bar-chart')
+    const data = JSON.parse(chart.dataset.chartData)
+    
+    // observacion = blue, seguridad = green
+    expect(data.datasets[0].backgroundColor[0]).toContain('66,105,225')
+    expect(data.datasets[0].backgroundColor[1]).toContain('32,139,34')
   })
 
   it('hides legend in options', () => {
@@ -96,5 +95,14 @@ describe('Niveles', () => {
     const options = JSON.parse(chart.dataset.chartOptions)
     
     expect(options.plugins.legend.display).toBe(false)
+  })
+
+  it('starts y-axis at zero', () => {
+    render(<Niveles embalses={mockEmbalses} />)
+    
+    const chart = screen.getByTestId('bar-chart')
+    const options = JSON.parse(chart.dataset.chartOptions)
+    
+    expect(options.scales.y.beginAtZero).toBe(true)
   })
 })

--- a/components/EmbalsesApi.js
+++ b/components/EmbalsesApi.js
@@ -1,17 +1,138 @@
 class EmbalsesApi {
   constructor () {
     this._embalses = [
-      {id: 50059000, commonName: 'Carraizo', nivelesDeAlerta: {desborde: 40.8, seguridad: 39.7, observacion: 38.5, ajustesOperacionales: 37.2, control: 31.5, fueraDeServicio: 0}},
-      {id: 50045000, commonName: 'La Plata', nivelesDeAlerta: {desborde: 51.3, seguridad: 47.7, observacion: 44.9, ajustesOperacionales: 40.5, control: 32, fueraDeServicio: 0}},
-      {id: 50047550, commonName: 'Cidra', nivelesDeAlerta: {desborde: 403, seguridad: 402, observacion: 401, ajustesOperacionales: 399.6, control: 398, fueraDeServicio: 0}},
-      {id: 50093045, commonName: 'Patillas', nivelesDeAlerta: {desborde: 66, seguridad: 62.18, observacion: 58.82, ajustesOperacionales: 57, control: 53.34, fueraDeServicio: 0}},
-      {id: 50111210, commonName: 'Toa Vaca', nivelesDeAlerta: {desborde: 161, seguridad: 152, observacion: 145, ajustesOperacionales: 139, control: 123, fueraDeServicio: 0}},
-      {id: 50039995, commonName: 'Carite', nivelesDeAlerta: {desborde: 544, seguridad: 542, observacion: 539, ajustesOperacionales: 537, control: 533, fueraDeServicio: 0}},
-      {id: 50076800, commonName: 'Rio Blanco', nivelesDeAlerta: {desborde: 28.75, seguridad: 26.5, observacion: 24.25, ajustesOperacionales: 22.5, control: 20, fueraDeServicio: 0}},
-      {id: 50026140, commonName: 'Caonillas', nivelesDeAlerta: {desborde: 252, seguridad: 248, observacion: 244, ajustesOperacionales: 242, control: 235, fueraDeServicio: 0}},
-      {id: 50071225, commonName: 'Fajardo', nivelesDeAlerta: {desborde: 52.5, seguridad: 48.3, observacion: 44.5, ajustesOperacionales: 40.5, control: 36, fueraDeServicio: 0}},
-      {id: 50010800, commonName: 'Guajataca', nivelesDeAlerta: {desborde: 196.9, seguridad: 194, observacion: 190, ajustesOperacionales: 186, control: 184, fueraDeServicio: 0}},
-      {id: 50113950, commonName: 'Cerrillos', nivelesDeAlerta: {desborde: 175, seguridad: 160, observacion: 155.5, ajustesOperacionales: 149.4, control: 137.2, fueraDeServicio: 0}}
+      {
+        id: 50059000,
+        commonName: 'Carraizo',
+        nivelesDeAlerta: {
+          desborde: 40.95,
+          seguridad: 39.7,
+          observacion: 38.5,
+          ajustesOperacionales: 37,
+          control: 30,
+          fueraDeServicio: 0
+        }
+      },
+      {
+        id: 50045000,
+        commonName: 'La Plata',
+        nivelesDeAlerta: {
+          desborde: 51.3,
+          seguridad: 47.7,
+          observacion: 44.9,
+          ajustesOperacionales: 40.5,
+          control: 30,
+          fueraDeServicio: 0
+        }
+      },
+      {
+        id: 50047550,
+        commonName: 'Cidra',
+        nivelesDeAlerta: {
+          desborde: 403,
+          seguridad: 401.71,
+          observacion: 400.23,
+          ajustesOperacionales: 398.37,
+          control: 395.5,
+          fueraDeServicio: 0
+        }
+      },
+      {
+        id: 50093045,
+        commonName: 'Patillas',
+        nivelesDeAlerta: {
+          desborde: 66,
+          seguridad: 62.18,
+          observacion: 58.82,
+          ajustesOperacionales: 57,
+          control: 53.34,
+          fueraDeServicio: 0
+        }
+      },
+      {
+        id: 50111210,
+        commonName: 'Toa Vaca',
+        nivelesDeAlerta: {
+          desborde: 164,
+          seguridad: 148,
+          observacion: 139.6,
+          ajustesOperacionales: 132.6,
+          control: 123,
+          fueraDeServicio: 0
+        }
+      },
+      {
+        id: 50039995,
+        commonName: 'Carite',
+        nivelesDeAlerta: {
+          desborde: 542.94,
+          seguridad: 541.16,
+          observacion: 538.16,
+          ajustesOperacionales: 536.16,
+          control: 532.16,
+          fueraDeServicio: 0
+        }
+      },
+      {
+        id: 50076800,
+        commonName: 'Rio Blanco',
+        nivelesDeAlerta: {
+          desborde: 28.75,
+          seguridad: 26.5,
+          observacion: 24.25,
+          ajustesOperacionales: 22.5,
+          control: 20,
+          fueraDeServicio: 0
+        }
+      },
+      {
+        id: 50026140,
+        commonName: 'Caonillas',
+        nivelesDeAlerta: {
+          desborde: 252,
+          seguridad: 248,
+          observacion: 244,
+          ajustesOperacionales: 242,
+          control: 235,
+          fueraDeServicio: 0
+        }
+      },
+      {
+        id: 50071225,
+        commonName: 'Fajardo',
+        nivelesDeAlerta: {
+          desborde: 52.5,
+          seguridad: 48.3,
+          observacion: 44.5,
+          ajustesOperacionales: 40.5,
+          control: 36,
+          fueraDeServicio: 0
+        }
+      },
+      {
+        id: 50010800,
+        commonName: 'Guajataca',
+        nivelesDeAlerta: {
+          desborde: 196.5,
+          seguridad: 194,
+          observacion: 190,
+          ajustesOperacionales: 186,
+          control: 184,
+          fueraDeServicio: 0
+        }
+      },
+      {
+        id: 50113950,
+        commonName: 'Cerrillos',
+        nivelesDeAlerta: {
+          desborde: 174.7,
+          seguridad: 160.9,
+          observacion: 152.4,
+          ajustesOperacionales: 144.8,
+          control: 137.5,
+          fueraDeServicio: 0
+        }
+      }
     ]
   }
 

--- a/components/EmbalsesApi.js
+++ b/components/EmbalsesApi.js
@@ -11,7 +11,7 @@ class EmbalsesApi {
       {id: 50026140, commonName: 'Caonillas', nivelesDeAlerta: {desborde: 252, seguridad: 248, observacion: 244, ajustesOperacionales: 242, control: 235, fueraDeServicio: 0}},
       {id: 50071225, commonName: 'Fajardo', nivelesDeAlerta: {desborde: 52.5, seguridad: 48.3, observacion: 44.5, ajustesOperacionales: 40.5, control: 36, fueraDeServicio: 0}},
       {id: 50010800, commonName: 'Guajataca', nivelesDeAlerta: {desborde: 196.9, seguridad: 194, observacion: 190, ajustesOperacionales: 186, control: 184, fueraDeServicio: 0}},
-      {id: 50125780, commonName: 'Cerrillos', nivelesDeAlerta: {desborde: 175, seguridad: 160, observacion: 155.5, ajustesOperacionales: 149.4, control: 137.2, fueraDeServicio: 0}}
+      {id: 50113950, commonName: 'Cerrillos', nivelesDeAlerta: {desborde: 175, seguridad: 160, observacion: 155.5, ajustesOperacionales: 149.4, control: 137.2, fueraDeServicio: 0}}
     ]
   }
 

--- a/components/EmbalsesMap.js
+++ b/components/EmbalsesMap.js
@@ -3,6 +3,7 @@ import { Fragment } from 'react'
 import { icon } from 'leaflet'
 import Link from 'next/link'
 import 'leaflet/dist/leaflet.css'
+import { useLanguage } from '../context/LanguageContext'
 
 const state = {
   lat: 18.2256014,
@@ -54,10 +55,11 @@ const greyIcon = icon({
   ...iconDefaults
 })
 
-const PopupMarker = (props) => {
+const PopupMarker = ({ embalse }) => {
+  const { t } = useLanguage()
   let myIcon
 
-  switch (props.embalse.currentAlert) {
+  switch (embalse.currentAlert) {
   case 'desborde':
     myIcon = violetIcon
     break
@@ -81,32 +83,32 @@ const PopupMarker = (props) => {
   }
 
   return (
-    <Marker position={props.embalse.geoLocation} icon={myIcon}>
+    <Marker position={embalse.geoLocation} icon={myIcon}>
       <Popup>
-        <Link href={`/embalse?id=${props.embalse.id}`}>
-          {props.embalse.commonName}
+        <Link href={`/embalse?id=${embalse.id}`}>
+          {embalse.commonName}
         </Link>
-        <p>Current Alert: {props.embalse.currentAlert}
-          <br />Current Level: {props.embalse.values[0].value} meters</p>
+        <p>{t('map.currentAlert')}: {t(`alerts.${embalse.currentAlert}`)}
+          <br />{t('map.currentLevel')}: {embalse.values[0].value} m</p>
       </Popup>
     </Marker>
   )
 }
 
-const MarkersList = (props) => {
-  const items = props.markers.map(marker => (
+const MarkersList = ({ markers }) => {
+  const items = markers.map(marker => (
     <PopupMarker key={marker.id} embalse={marker} />
   ))
   return <Fragment>{items}</Fragment>
 }
 
-const EmbalsesMap = (props) => (
+const EmbalsesMap = ({ embalses }) => (
   <MapContainer center={position} zoom={state.zoom} style={{ height: '400px', width: '100%' }}>
     <TileLayer
       attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
       url='https://{s}.tile.osm.org/{z}/{x}/{y}.png'
       />
-    <MarkersList markers={props.embalses} />
+    <MarkersList markers={embalses} />
   </MapContainer>
 )
 

--- a/components/EmbalsesTable.js
+++ b/components/EmbalsesTable.js
@@ -1,40 +1,43 @@
 import Link from 'next/link'
+import { useLanguage } from '../context/LanguageContext'
 
-function deCamelCase(camelCase) {
-  return camelCase
-    .replace(/([A-Z])/g, ' $1')
-    .replace(/^./, function (str) { return str.toUpperCase() })
+const EmbalseRow = ({ embalse }) => {
+  const { t } = useLanguage()
+  
+  return (
+    <tr>
+      <td>
+        <Link href={`/embalse?id=${embalse.id}`}>
+          {embalse.commonName}
+        </Link>
+      </td>
+      <td>{new Date(embalse.values[0].dateTime).toString()}</td>
+      <td>{t(`alerts.${embalse.currentAlert}`)}</td>
+      <td>{embalse.values[0].value}</td>
+    </tr>
+  )
 }
 
-const EmbalseRow = props => (
-  <tr>
-    <td>
-      <Link href={`/embalse?id=${props.embalse.id}`}>
-        {props.embalse.commonName}
-      </Link>
-    </td>
-    <td>{new Date(props.embalse.values[0].dateTime).toString()}</td>
-    <td>{deCamelCase(props.embalse.currentAlert)}</td>
-    <td>{props.embalse.values[0].value}</td>
-  </tr>
-)
+const EmbalsesTable = ({ embalses }) => {
+  const { t } = useLanguage()
 
-const EmbalsesTable = props => (
-  <table className='table table-striped'>
-    <thead>
-      <tr>
-        <th scope='col'>Embalse</th>
-        <th scope='col'>Last Updated</th>
-        <th scope='col'>Current Alert</th>
-        <th scope='col'>Current Level (meters)</th>
-      </tr>
-    </thead>
-    <tbody>
-      {props.embalses.map(embalse => (
-        <EmbalseRow embalse={embalse} key={embalse.id} />
-      ))}
-    </tbody>
-  </table>
-)
+  return (
+    <table className='table table-striped'>
+      <thead>
+        <tr>
+          <th scope='col'>{t('table.embalse')}</th>
+          <th scope='col'>{t('table.lastUpdated')}</th>
+          <th scope='col'>{t('table.currentAlert')}</th>
+          <th scope='col'>{t('table.currentLevel')}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {embalses.map(embalse => (
+          <EmbalseRow embalse={embalse} key={embalse.id} />
+        ))}
+      </tbody>
+    </table>
+  )
+}
 
 export default EmbalsesTable

--- a/components/Header.js
+++ b/components/Header.js
@@ -1,20 +1,35 @@
 import Link from 'next/link'
+import { useLanguage } from '../context/LanguageContext'
 
-const Header = () => (
-  <ul className='nav'>
-    <li className='nav-item'>
-      <Link href='/' className='nav-link'>Home</Link>
-    </li>
-    <li className='nav-item'>
-      <Link href='/map' className='nav-link'>Map</Link>
-    </li>
-    <li className='nav-item'>
-      <Link href='/table' className='nav-link'>Table</Link>
-    </li>
-    <li className='nav-item'>
-      <Link href='/about' className='nav-link'>About</Link>
-    </li>
-  </ul>
-)
+const Header = () => {
+  const { t, locale, toggleLanguage } = useLanguage()
+
+  return (
+    <nav className='navbar navbar-expand-lg navbar-light bg-light mb-4'>
+      <div className='container'>
+        <ul className='navbar-nav me-auto mb-2 mb-lg-0'>
+          <li className='nav-item'>
+            <Link href='/' className='nav-link'>{t('common.home')}</Link>
+          </li>
+          <li className='nav-item'>
+            <Link href='/map' className='nav-link'>{t('common.map')}</Link>
+          </li>
+          <li className='nav-item'>
+            <Link href='/table' className='nav-link'>{t('common.table')}</Link>
+          </li>
+          <li className='nav-item'>
+            <Link href='/about' className='nav-link'>{t('common.about')}</Link>
+          </li>
+        </ul>
+        <button 
+          className='btn btn-outline-secondary btn-sm' 
+          onClick={toggleLanguage}
+        >
+          {locale === 'es' ? 'EN' : 'ES'}
+        </button>
+      </div>
+    </nav>
+  )
+}
 
 export default Header

--- a/components/Niveles.js
+++ b/components/Niveles.js
@@ -31,8 +31,12 @@ class Niveles extends Component {
     const data = {
       labels: embalses.map(embalse => embalse.commonName),
       datasets: [{
-        label: 'Nivel Actual',
-        data: embalses.map(embalse => parseFloat(embalse.values[0].value)),
+        label: 'Nivel Actual (%)',
+        data: embalses.map(embalse => {
+          const currentValue = parseFloat(embalse.values[0].value)
+          const desbordeLevel = embalse.alertLevels.desborde
+          return Math.round((currentValue / desbordeLevel) * 100)
+        }),
         backgroundColor: embalses.map(embalse => this.getColor(embalse.currentAlert, 0.6)),
         borderColor: embalses.map(embalse => this.getColor(embalse.currentAlert, 1)),
         borderWidth: 2
@@ -77,7 +81,7 @@ class Niveles extends Component {
           clamp: true,
           anchor: 'end',
           align: 'top',
-          formatter: (value) => value + ' m',
+          formatter: (value) => value + '%',
           font: {
             weight: 'bold'
           }
@@ -85,6 +89,11 @@ class Niveles extends Component {
         legend: { display: false },
         tooltip: {
           callbacks: {
+            label: (context) => {
+              const embalse = embalses[context.dataIndex]
+              const currentValue = parseFloat(embalse.values[0].value)
+              return `${currentValue} m (${context.raw}% de desborde)`
+            },
             afterLabel: (context) => {
               const embalse = embalses[context.dataIndex]
               return `Alerta: ${embalse.currentAlert}`
@@ -95,9 +104,13 @@ class Niveles extends Component {
       scales: {
         y: {
           beginAtZero: true,
+          max: 100,
           title: {
             display: true,
-            text: 'Nivel (metros)'
+            text: '% de Nivel de Desborde'
+          },
+          ticks: {
+            callback: (value) => value + '%'
           }
         }
       }

--- a/components/Niveles.js
+++ b/components/Niveles.js
@@ -34,8 +34,11 @@ class Niveles extends Component {
         label: 'Nivel Actual (%)',
         data: embalses.map(embalse => {
           const currentValue = parseFloat(embalse.values[0].value)
+          const controlLevel = embalse.alertLevels.control
           const desbordeLevel = embalse.alertLevels.desborde
-          return Math.round((currentValue / desbordeLevel) * 100)
+          const range = desbordeLevel - controlLevel
+          const percentage = ((currentValue - controlLevel) / range) * 100
+          return Math.round(Math.max(0, Math.min(100, percentage)))
         }),
         backgroundColor: embalses.map(embalse => this.getColor(embalse.currentAlert, 0.6)),
         borderColor: embalses.map(embalse => this.getColor(embalse.currentAlert, 1)),

--- a/components/Niveles.js
+++ b/components/Niveles.js
@@ -92,7 +92,7 @@ class Niveles extends Component {
             label: (context) => {
               const embalse = embalses[context.dataIndex]
               const currentValue = parseFloat(embalse.values[0].value)
-              return `${currentValue} m (${context.raw}% de desborde)`
+              return `${currentValue} m`
             },
             afterLabel: (context) => {
               const embalse = embalses[context.dataIndex]

--- a/components/Niveles.js
+++ b/components/Niveles.js
@@ -79,6 +79,11 @@ class Niveles extends Component {
     return {
       responsive: true,
       maintainAspectRatio: true,
+      layout: {
+        padding: {
+          top: 20
+        }
+      },
       plugins: {
         datalabels: {
           clamp: true,

--- a/components/Niveles.js
+++ b/components/Niveles.js
@@ -29,28 +29,19 @@ class Niveles extends Component {
 
   processData (embalses) {
     const data = {
-      labels: embalses.map(embalse => { return embalse.commonName }),
-      datasets: embalses.map(embalse => {
-        const index = embalses.findIndex(emb => emb.id === embalse.id)
-        const data = new Array(index).fill(null)
-        data.push(embalses[index].values[0].value)
-        return {
-          label: embalse.currentAlert,
-          yAxisID: embalse.id,
-          data: data,
-          ...this.processColors(embalse.currentAlert)
-        }
-      })
+      labels: embalses.map(embalse => embalse.commonName),
+      datasets: [{
+        label: 'Nivel Actual',
+        data: embalses.map(embalse => parseFloat(embalse.values[0].value)),
+        backgroundColor: embalses.map(embalse => this.getColor(embalse.currentAlert, 0.6)),
+        borderColor: embalses.map(embalse => this.getColor(embalse.currentAlert, 1)),
+        borderWidth: 2
+      }]
     }
     return data
   }
 
-  processColors (currentAlert) {
-    const backgroundAlpha = 0.2
-    const borderAlpha = 1
-    const hoverBackgroundAlpha = 0.4
-    const hoverBorderAlpha = 1
-
+  getColor (currentAlert, alpha) {
     let rgb = '236,236,236' // gray default
 
     switch (currentAlert) {
@@ -74,27 +65,42 @@ class Niveles extends Component {
       break
     }
 
-    const colors = {
-      backgroundColor: `rgba(${rgb},${backgroundAlpha})`,
-      borderColor: `rgba(${rgb},${borderAlpha})`,
-      hoverBackgroundColor: `rgba(${rgb},${hoverBackgroundAlpha})`,
-      hoverBorderColor: `rgba(${rgb},${hoverBorderAlpha})`
-    }
-
-    return colors
+    return `rgba(${rgb},${alpha})`
   }
 
-  processOptions (_embalses) {
+  processOptions (embalses) {
     return {
+      responsive: true,
+      maintainAspectRatio: true,
       plugins: {
         datalabels: {
           clamp: true,
-          anchor: 'start',
-          align: 'top'
+          anchor: 'end',
+          align: 'top',
+          formatter: (value) => value + ' m',
+          font: {
+            weight: 'bold'
+          }
         },
-        legend: { display: false }
+        legend: { display: false },
+        tooltip: {
+          callbacks: {
+            afterLabel: (context) => {
+              const embalse = embalses[context.dataIndex]
+              return `Alerta: ${embalse.currentAlert}`
+            }
+          }
+        }
       },
-      scales: {}
+      scales: {
+        y: {
+          beginAtZero: true,
+          title: {
+            display: true,
+            text: 'Nivel (metros)'
+          }
+        }
+      }
     }
   }
 

--- a/context/LanguageContext.js
+++ b/context/LanguageContext.js
@@ -1,0 +1,40 @@
+import { createContext, useContext, useState } from 'react'
+import es from '../locales/es.json'
+import en from '../locales/en.json'
+
+const translations = { es, en }
+
+const LanguageContext = createContext()
+
+export function LanguageProvider({ children }) {
+  const [locale, setLocale] = useState('es')
+
+  const t = (key) => {
+    const keys = key.split('.')
+    let value = translations[locale]
+    
+    for (const k of keys) {
+      value = value?.[k]
+    }
+    
+    return value || key
+  }
+
+  const toggleLanguage = () => {
+    setLocale(prev => prev === 'es' ? 'en' : 'es')
+  }
+
+  return (
+    <LanguageContext.Provider value={{ locale, setLocale, t, toggleLanguage }}>
+      {children}
+    </LanguageContext.Provider>
+  )
+}
+
+export function useLanguage() {
+  const context = useContext(LanguageContext)
+  if (!context) {
+    throw new Error('useLanguage must be used within a LanguageProvider')
+  }
+  return context
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -28,6 +28,14 @@
     "color": "Color",
     "alertLevel": "Alert Level"
   },
+  "colors": {
+    "purple": "Purple",
+    "green": "Green",
+    "blue": "Blue",
+    "yellow": "Yellow",
+    "orange": "Orange",
+    "red": "Red"
+  },
   "alerts": {
     "desborde": "Overflow",
     "seguridad": "Safety",
@@ -35,13 +43,5 @@
     "ajustesOperacionales": "Operational Adjustments",
     "control": "Control",
     "fueraDeServicio": "Out of Service"
-  },
-  "alertDescriptions": {
-    "desborde": "Reservoir level is above the overflow level. Risk of flooding.",
-    "seguridad": "Level is within the operational safety range.",
-    "observacion": "Level requires continuous observation.",
-    "ajustesOperacionales": "Adjustments to reservoir operations are required.",
-    "control": "Level is under control within normal parameters.",
-    "fueraDeServicio": "Reservoir is out of service or no data available."
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -22,7 +22,11 @@
   },
   "about": {
     "title": "About",
-    "description": "A real-time dashboard for monitoring water reservoir levels across Puerto Rico, using data from the USGS Water Services API."
+    "description": "A real-time dashboard for monitoring water reservoir levels across Puerto Rico, using data from the USGS Water Services API.",
+    "colorLegend": "Color Legend",
+    "colorLegendDescription": "Colors on the map and table indicate the current alert level of each reservoir:",
+    "color": "Color",
+    "alertLevel": "Alert Level"
   },
   "alerts": {
     "desborde": "Overflow",
@@ -31,5 +35,13 @@
     "ajustesOperacionales": "Operational Adjustments",
     "control": "Control",
     "fueraDeServicio": "Out of Service"
+  },
+  "alertDescriptions": {
+    "desborde": "Reservoir level is above the overflow level. Risk of flooding.",
+    "seguridad": "Level is within the operational safety range.",
+    "observacion": "Level requires continuous observation.",
+    "ajustesOperacionales": "Adjustments to reservoir operations are required.",
+    "control": "Level is under control within normal parameters.",
+    "fueraDeServicio": "Reservoir is out of service or no data available."
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,35 @@
+{
+  "common": {
+    "home": "Home",
+    "map": "Map",
+    "table": "Table",
+    "about": "About"
+  },
+  "home": {
+    "title": "Puerto Rico Reservoir Levels"
+  },
+  "map": {
+    "title": "Reservoir Map",
+    "currentAlert": "Current Alert",
+    "currentLevel": "Current Level"
+  },
+  "table": {
+    "title": "Reservoir Data",
+    "embalse": "Reservoir",
+    "lastUpdated": "Last Updated",
+    "currentAlert": "Current Alert",
+    "currentLevel": "Current Level (meters)"
+  },
+  "about": {
+    "title": "About",
+    "description": "A real-time dashboard for monitoring water reservoir levels across Puerto Rico, using data from the USGS Water Services API."
+  },
+  "alerts": {
+    "desborde": "Overflow",
+    "seguridad": "Safety",
+    "observacion": "Observation",
+    "ajustesOperacionales": "Operational Adjustments",
+    "control": "Control",
+    "fueraDeServicio": "Out of Service"
+  }
+}

--- a/locales/es.json
+++ b/locales/es.json
@@ -28,6 +28,14 @@
     "color": "Color",
     "alertLevel": "Nivel de Alerta"
   },
+  "colors": {
+    "purple": "Morado",
+    "green": "Verde",
+    "blue": "Azul",
+    "yellow": "Amarillo",
+    "orange": "Naranja",
+    "red": "Rojo"
+  },
   "alerts": {
     "desborde": "Desborde",
     "seguridad": "Seguridad",
@@ -35,13 +43,5 @@
     "ajustesOperacionales": "Ajustes Operacionales",
     "control": "Control",
     "fueraDeServicio": "Fuera de Servicio"
-  },
-  "alertDescriptions": {
-    "desborde": "El nivel del embalse está por encima del nivel de desborde. Riesgo de inundación.",
-    "seguridad": "El nivel está en el rango de seguridad operacional.",
-    "observacion": "El nivel requiere observación continua.",
-    "ajustesOperacionales": "Se requieren ajustes en las operaciones del embalse.",
-    "control": "El nivel está bajo control dentro de los parámetros normales.",
-    "fueraDeServicio": "El embalse está fuera de servicio o sin datos disponibles."
   }
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -22,7 +22,11 @@
   },
   "about": {
     "title": "Acerca de",
-    "description": "Un panel de control en tiempo real para monitorear los niveles de agua de los embalses en Puerto Rico, utilizando datos de la API de Servicios de Agua de USGS."
+    "description": "Un panel de control en tiempo real para monitorear los niveles de agua de los embalses en Puerto Rico, utilizando datos de la API de Servicios de Agua de USGS.",
+    "colorLegend": "Leyenda de Colores",
+    "colorLegendDescription": "Los colores en el mapa y la tabla indican el nivel de alerta actual de cada embalse:",
+    "color": "Color",
+    "alertLevel": "Nivel de Alerta"
   },
   "alerts": {
     "desborde": "Desborde",
@@ -31,5 +35,13 @@
     "ajustesOperacionales": "Ajustes Operacionales",
     "control": "Control",
     "fueraDeServicio": "Fuera de Servicio"
+  },
+  "alertDescriptions": {
+    "desborde": "El nivel del embalse está por encima del nivel de desborde. Riesgo de inundación.",
+    "seguridad": "El nivel está en el rango de seguridad operacional.",
+    "observacion": "El nivel requiere observación continua.",
+    "ajustesOperacionales": "Se requieren ajustes en las operaciones del embalse.",
+    "control": "El nivel está bajo control dentro de los parámetros normales.",
+    "fueraDeServicio": "El embalse está fuera de servicio o sin datos disponibles."
   }
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -1,0 +1,35 @@
+{
+  "common": {
+    "home": "Inicio",
+    "map": "Mapa",
+    "table": "Tabla",
+    "about": "Acerca de"
+  },
+  "home": {
+    "title": "Niveles de Embalses de Puerto Rico"
+  },
+  "map": {
+    "title": "Mapa de Embalses",
+    "currentAlert": "Alerta Actual",
+    "currentLevel": "Nivel Actual"
+  },
+  "table": {
+    "title": "Datos de Embalses",
+    "embalse": "Embalse",
+    "lastUpdated": "Última Actualización",
+    "currentAlert": "Alerta Actual",
+    "currentLevel": "Nivel Actual (metros)"
+  },
+  "about": {
+    "title": "Acerca de",
+    "description": "Un panel de control en tiempo real para monitorear los niveles de agua de los embalses en Puerto Rico, utilizando datos de la API de Servicios de Agua de USGS."
+  },
+  "alerts": {
+    "desborde": "Desborde",
+    "seguridad": "Seguridad",
+    "observacion": "Observación",
+    "ajustesOperacionales": "Ajustes Operacionales",
+    "control": "Control",
+    "fueraDeServicio": "Fuera de Servicio"
+  }
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,10 @@
 import 'bootstrap/dist/css/bootstrap.css'
+import { LanguageProvider } from '../context/LanguageContext'
 
 export default function MyApp ({ Component, pageProps }) {
-  return <Component {...pageProps} />
+  return (
+    <LanguageProvider>
+      <Component {...pageProps} />
+    </LanguageProvider>
+  )
 }

--- a/pages/about.js
+++ b/pages/about.js
@@ -1,6 +1,15 @@
 import Layout from '../components/MyLayout.js'
 import { useLanguage } from '../context/LanguageContext'
 
+const alertColors = [
+  { key: 'desborde', color: '#9500D3', bgColor: 'rgba(149, 0, 211, 0.2)' },
+  { key: 'seguridad', color: '#208B22', bgColor: 'rgba(32, 139, 34, 0.2)' },
+  { key: 'observacion', color: '#4269E1', bgColor: 'rgba(66, 105, 225, 0.2)' },
+  { key: 'ajustesOperacionales', color: '#FFFF04', bgColor: 'rgba(255, 255, 4, 0.2)' },
+  { key: 'control', color: '#FFA502', bgColor: 'rgba(255, 165, 2, 0.2)' },
+  { key: 'fueraDeServicio', color: '#C00100', bgColor: 'rgba(192, 1, 0, 0.2)' },
+]
+
 const About = () => {
   const { t } = useLanguage()
 
@@ -8,6 +17,46 @@ const About = () => {
     <Layout>
       <h1>{t('about.title')}</h1>
       <p>{t('about.description')}</p>
+      
+      <h2 className='mt-4'>{t('about.colorLegend')}</h2>
+      <p>{t('about.colorLegendDescription')}</p>
+      
+      <div className='table-responsive'>
+        <table className='table table-bordered'>
+          <thead>
+            <tr>
+              <th style={{ width: '150px' }}>{t('about.color')}</th>
+              <th>{t('about.alertLevel')}</th>
+              <th>{t('about.description')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {alertColors.map(({ key, color, bgColor }) => (
+              <tr key={key}>
+                <td>
+                  <span 
+                    style={{ 
+                      display: 'inline-block',
+                      width: '24px',
+                      height: '24px',
+                      backgroundColor: bgColor,
+                      borderColor: color,
+                      borderWidth: '2px',
+                      borderStyle: 'solid',
+                      borderRadius: '4px',
+                      verticalAlign: 'middle',
+                      marginRight: '8px'
+                    }}
+                  />
+                  <code>{color}</code>
+                </td>
+                <td>{t(`alerts.${key}`)}</td>
+                <td>{t(`alertDescriptions.${key}`)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </Layout>
   )
 }

--- a/pages/about.js
+++ b/pages/about.js
@@ -2,12 +2,12 @@ import Layout from '../components/MyLayout.js'
 import { useLanguage } from '../context/LanguageContext'
 
 const alertColors = [
-  { key: 'desborde', color: '#9500D3', bgColor: 'rgba(149, 0, 211, 0.2)' },
-  { key: 'seguridad', color: '#208B22', bgColor: 'rgba(32, 139, 34, 0.2)' },
-  { key: 'observacion', color: '#4269E1', bgColor: 'rgba(66, 105, 225, 0.2)' },
-  { key: 'ajustesOperacionales', color: '#FFFF04', bgColor: 'rgba(255, 255, 4, 0.2)' },
-  { key: 'control', color: '#FFA502', bgColor: 'rgba(255, 165, 2, 0.2)' },
-  { key: 'fueraDeServicio', color: '#C00100', bgColor: 'rgba(192, 1, 0, 0.2)' },
+  { key: 'desborde', color: '#9500D3', bgColor: 'rgba(149, 0, 211, 0.2)', colorName: 'purple' },
+  { key: 'seguridad', color: '#208B22', bgColor: 'rgba(32, 139, 34, 0.2)', colorName: 'green' },
+  { key: 'observacion', color: '#4269E1', bgColor: 'rgba(66, 105, 225, 0.2)', colorName: 'blue' },
+  { key: 'ajustesOperacionales', color: '#FFFF04', bgColor: 'rgba(255, 255, 4, 0.2)', colorName: 'yellow' },
+  { key: 'control', color: '#FFA502', bgColor: 'rgba(255, 165, 2, 0.2)', colorName: 'orange' },
+  { key: 'fueraDeServicio', color: '#C00100', bgColor: 'rgba(192, 1, 0, 0.2)', colorName: 'red' },
 ]
 
 const About = () => {
@@ -25,13 +25,12 @@ const About = () => {
         <table className='table table-bordered'>
           <thead>
             <tr>
-              <th style={{ width: '150px' }}>{t('about.color')}</th>
+              <th>{t('about.color')}</th>
               <th>{t('about.alertLevel')}</th>
-              <th>{t('about.description')}</th>
             </tr>
           </thead>
           <tbody>
-            {alertColors.map(({ key, color, bgColor }) => (
+            {alertColors.map(({ key, color, bgColor, colorName }) => (
               <tr key={key}>
                 <td>
                   <span 
@@ -48,10 +47,9 @@ const About = () => {
                       marginRight: '8px'
                     }}
                   />
-                  <code>{color}</code>
+                  {t(`colors.${colorName}`)}
                 </td>
                 <td>{t(`alerts.${key}`)}</td>
-                <td>{t(`alertDescriptions.${key}`)}</td>
               </tr>
             ))}
           </tbody>

--- a/pages/about.js
+++ b/pages/about.js
@@ -1,9 +1,15 @@
 import Layout from '../components/MyLayout.js'
+import { useLanguage } from '../context/LanguageContext'
 
-const About = () => (
-  <Layout>
-    <p>This is the about page</p>
-  </Layout>
-)
+const About = () => {
+  const { t } = useLanguage()
+
+  return (
+    <Layout>
+      <h1>{t('about.title')}</h1>
+      <p>{t('about.description')}</p>
+    </Layout>
+  )
+}
 
 export default About

--- a/pages/index.js
+++ b/pages/index.js
@@ -24,12 +24,12 @@ Index.getInitialProps = async function () {
 
   try {
     const res = await fetch(`https://waterservices.usgs.gov/nwis/iv/?format=json&sites=${sites}&parameterCd=72376&siteStatus=all`, {mode: 'cors'})
-    
+
     if (!res.ok) {
       console.error('USGS API error:', res.status, res.statusText)
       return { embalses: [] }
     }
-    
+
     const data = await res.json()
     return { embalses: myEmbalses.processUsgsEmbalses(data) }
   } catch (error) {

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,17 +1,22 @@
 import Layout from '../components/MyLayout.js'
 import EmbalsesApi from '../components/EmbalsesApi.js'
 import Niveles from '../components/Niveles.js'
+import { useLanguage } from '../context/LanguageContext'
 
-const Index = (props) => (
-  <Layout>
-    <h1>Puerto Rico Reservoir Levels</h1>
-    <div className='row'>
-      <div className='col'>
-        <Niveles embalses={props.embalses} />
+const Index = (props) => {
+  const { t } = useLanguage()
+
+  return (
+    <Layout>
+      <h1>{t('home.title')}</h1>
+      <div className='row'>
+        <div className='col'>
+          <Niveles embalses={props.embalses} />
+        </div>
       </div>
-    </div>
-  </Layout>
-)
+    </Layout>
+  )
+}
 
 Index.getInitialProps = async function () {
   const myEmbalses = new EmbalsesApi()

--- a/pages/map.js
+++ b/pages/map.js
@@ -1,15 +1,20 @@
 import Layout from '../components/MyLayout.js'
 import EmbalsesApi from '../components/EmbalsesApi.js'
 import dynamic from 'next/dynamic'
+import { useLanguage } from '../context/LanguageContext'
 
 const EmbalsesMap = dynamic(() => import('../components/EmbalsesMap.js'), {ssr: false})
 
-const MapPage = (props) => (
-  <Layout>
-    <h1>Reservoir Map</h1>
-    <EmbalsesMap embalses={props.embalses} />
-  </Layout>
-)
+const MapPage = (props) => {
+  const { t } = useLanguage()
+
+  return (
+    <Layout>
+      <h1>{t('map.title')}</h1>
+      <EmbalsesMap embalses={props.embalses} />
+    </Layout>
+  )
+}
 
 MapPage.getInitialProps = async function () {
   const myEmbalses = new EmbalsesApi()

--- a/pages/table.js
+++ b/pages/table.js
@@ -1,13 +1,18 @@
 import Layout from '../components/MyLayout.js'
 import EmbalsesApi from '../components/EmbalsesApi.js'
 import EmbalsesTable from '../components/EmbalsesTable.js'
+import { useLanguage } from '../context/LanguageContext'
 
-const TablePage = (props) => (
-  <Layout>
-    <h1>Reservoir Data</h1>
-    <EmbalsesTable embalses={props.embalses} />
-  </Layout>
-)
+const TablePage = (props) => {
+  const { t } = useLanguage()
+
+  return (
+    <Layout>
+      <h1>{t('table.title')}</h1>
+      <EmbalsesTable embalses={props.embalses} />
+    </Layout>
+  )
+}
 
 TablePage.getInitialProps = async function () {
   const myEmbalses = new EmbalsesApi()


### PR DESCRIPTION
## Changes
- Add language context for translations
- Create translation files for Spanish (es) and English (en)
- Add language toggle button in header
- Update all components to use translations

## Default Language
Spanish (es) - can be toggled to English (en) via button in header

## Translated Items
- Navigation links
- Page titles
- Table headers
- Alert level names
- Map popup labels

## Testing
- All 42 tests pass
- Updated tests to work with LanguageProvider